### PR TITLE
Added missing final '.' in privoxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ sudo vim /etc/privoxy/config
 and enable **forward-socks5** as follows:
 	
 ```
-forward-socks5 / 127.0.0.1:9050
+forward-socks5 / 127.0.0.1:9050 .
 ```
 
 Restart **privoxy** after making the change to the configuration file.


### PR DESCRIPTION
There is a missing `.` in `/etc/privoxy/config` when enabling __forward-socks5__